### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish
+
+on:
+  push:
+    branches: [ release ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Archive
+      shell: bash
+      run: git archive --output=git-katas.zip HEAD
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: git-katas.zip
+        path: git-katas.zip


### PR DESCRIPTION
This is a precursor to our upcoming release pipeline (making katas accessible without git clone).
It only archives them in the workflow now, but it's a start.