### PR TITLE
Add fake remote to advanced-rebase-interactive

### DIFF
--- a/advanced-rebase-interactive/setup.sh
+++ b/advanced-rebase-interactive/setup.sh
@@ -2,11 +2,15 @@
 #Include utils
 source ../utils/utils.sh
 
-make-exercise-repo
+make-bare-remote-repo 
+clone-remote-to-exercise
 
 git commit --allow-empty -m "Initial commit"
 
 git tag v0.0
+
+git push origin master
+git push origin v0.0
 
 echo "Hello" > hello.code
 git add hello.code
@@ -21,7 +25,7 @@ git commit -am "Finished HW feature"
 echo "Hello World!" > hello.code
 git commit -am "Really made the thingy done"
 
-echo "println DEBUG" > hello.code
+echo "println DEBUG" >> hello.code
 git commit -am "debugging"
 
 echo "4321pass" > private.secret


### PR DESCRIPTION
Updated the advanced-rebase-interactive exercise to use same "fake remote" mechanism as reorder-the-history so that it gets a real origin/master that we can rebase back to.

I left the tag in there for now, and left the README as is, as the make-fake-remote.sh util has not yet been ported to PowerShell.