### PR TITLE
Add feature to test all kata setup.sh scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     - name: Run bash test scripts
       shell: bash
       run: |
+        git config user.name "GitHub Actions"
+        git config user.email "nobody@localhost"
         chmod +x ./test-all.sh
         ./test-all.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Run bash test scripts
       shell: bash
       run: |
-        git config user.name "GitHub Actions"
-        git config user.email "nobody@localhost"
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "nobody@localhost"
         chmod +x ./test-all.sh
         ./test-all.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Run bash test scripts
       shell: bash
       run: |
-        chmod +x ./test.sh
-        ./test.sh
+        chmod +x ./test-all.sh
+        ./test-all.sh
 
   setup-bash-macos:
     runs-on: macos-latest
@@ -28,8 +28,8 @@ jobs:
     - name: Run bash test scripts
       shell: bash
       run: |
-        chmod +x ./test.sh
-        ./test.sh
+        chmod +x ./test-all.sh
+        ./test-all.sh
 
   setup-pwsh:
     runs-on: ubuntu-latest

--- a/git-attributes/setup.ps1
+++ b/git-attributes/setup.ps1
@@ -2,5 +2,4 @@
 
 Set-Content -Value "hello æøå`r`n" -Path file1.txt
 
-git init
 git checkout -b master

--- a/git-attributes/setup.sh
+++ b/git-attributes/setup.sh
@@ -7,5 +7,4 @@ kata="git-attributes"
 make-exercise-repo
 
 printf 'hello æøå\r\n' > file1.txt
-git init
 git checkout -b master

--- a/git-tag/setup.sh
+++ b/git-tag/setup.sh
@@ -11,5 +11,6 @@ git add dummy.txt
 git commit -m "dummy commit"
 git tag "dummy"
 echo "dummy2" > dummy.txt
+git add dummy.txt
 git commit -m "adding more content to dummy.txt"
 git tag -a "dummy2" -m "don't worry, be happy"

--- a/ignore/setup.ps1
+++ b/ignore/setup.ps1
@@ -2,5 +2,4 @@
 
 Set-Content -Value "hello" -Path file1.txt
 
-git init
 git checkout -b master

--- a/ignore/setup.sh
+++ b/ignore/setup.sh
@@ -7,5 +7,4 @@ kata="basic-ignore"
 make-exercise-repo
 
 echo "hello" > file1.txt
-git init
 git checkout -b master

--- a/master-based-workflow/setup.ps1
+++ b/master-based-workflow/setup.ps1
@@ -7,7 +7,7 @@ New-Item -Name "exercise" -ItemType "directory" | Out-Null
 Copy-Item fitzgerald-pushes-before-we-do.ps1 ./exercise
 Set-Location exercise
 
-git init fake-remote-repository
+git  -c init.defaultBranch=master init fake-remote-repository
 Push-Location fake-remote-repository 
 
 Set-Content -Value "" -Path README.md

--- a/master-based-workflow/setup.sh
+++ b/master-based-workflow/setup.sh
@@ -7,7 +7,7 @@ mkdir exercise
 cp fitzgerald-pushes-before-we-do.sh ./exercise/
 cd exercise
 
-git init fake-remote-repository
+git  -c init.defaultBranch="$DEFAULT_BRANCH" init fake-remote-repository
 pushd fake-remote-repository 
 touch README.md
 git add README.md

--- a/reverted-merge/setup.sh
+++ b/reverted-merge/setup.sh
@@ -31,7 +31,7 @@ git add mymodule.txt
 git commit -m"Add feature X"
 
 
-git merge integrate-library-1.2.4 --no-edit
+git merge integrate-library-1.2.4 --no-edit || true
 # deal with merge conflict
 echo "module using library-1.2.4" > mymodule.txt
 echo "Promising feature X" >> mymodule.txt

--- a/submodules/setup.ps1
+++ b/submodules/setup.ps1
@@ -8,7 +8,7 @@ New-Item -ItemType Directory -Path exercise | Out-Null
 Set-Location .\exercise
 
 # Create remote repo
-git init --bare remote
+git -c init.defaultBranch=master init --bare remote
 
 
 git config --local user.name "git-katas trainer bot"
@@ -28,7 +28,7 @@ git push
 Set-Location ..
 
 # Create a product repo
-git init product
+git -c init.defaultBranch=master init product
 
 Set-Location -Path .\product
 

--- a/submodules/setup.sh
+++ b/submodules/setup.sh
@@ -26,7 +26,7 @@ git push
 cd ..
 
 # Create a product repo
-git init product
+git -c init.defaultBranch="$DEFAULT_BRANCH" init product
 
 # Commit a file to the product repo
 cd product

--- a/subtree/setup.sh
+++ b/subtree/setup.sh
@@ -26,7 +26,7 @@ cd ${EXERCISE_DIR}
 mkdir component
 
 cd component
-git init
+git -c init.defaultBranch=master init
 echo "1st component commit" >> component.h
 git add component.h
 git commit -m "1st component commit"
@@ -35,7 +35,7 @@ cd ..
 
 mkdir product
 cd product
-git init
+git -c init.defaultBranch=master init
 echo "1st  product commit" >> product.h
 git add product.h
 git commit -m "1st product commit"

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+RC='\033[0m' # Reset Color
 
 basedir=$(git rev-parse --show-toplevel)
 
@@ -6,16 +9,26 @@ echo "Testing all kata setup scripts"
 
 function test-setup (){
   return_code=0
+  failed=0
+  total=0
   scripts=$(find . -name "setup.sh" -type f -print | sort)
   for script in ${scripts}; do
-    cd "$(dirname "${script}")" || exit 2
+    ((total++))
+    cd "$(dirname "${script}")" || exit
     ../utils/test/test_setup.sh setup.sh
     exit_code=$?
     if [ ${exit_code} -ne 0 ]; then
       return_code=${exit_code}
+      ((failed++))
     fi
-    cd "$basedir" || exit 2
+    cd "$basedir" || exit
   done
+
+  if [ ${return_code} -ne 0 ]; then
+    echo -e "${RED}Failed $failed${RC} of $total tests."
+  else
+    echo -e "All $total tests completed ${GREEN}successfully.${RC}"
+  fi
   return $return_code
 }
 

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
 
+basedir=$(git rev-parse --show-toplevel)
+
 echo "Testing all kata setup scripts"
-find -s . -name "setup.sh" -type f -execdir ../utils/test/test_setup.sh  \;
+
+function test-setup (){
+  return_code=0
+  scripts=$(find . -name "setup.sh" -type f -print | sort)
+  for script in ${scripts}; do
+    cd $(dirname ${script})
+    ../utils/test/test_setup.sh setup.sh
+    exit_code=$?
+    if [ ${exit_code} -ne 0 ]; then
+      return_code=${exit_code}
+    fi
+    cd $basedir
+  done
+  return $return_code
+}
+
+test-setup

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 echo "Testing all kata setup scripts"
-find . -name "setup.sh" -type f -execdir ../utils/test/test_setup.sh  \;
+find -s . -name "setup.sh" -type f -execdir ../utils/test/test_setup.sh  \;

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Testing all kata setup scripts"
+find . -name "setup.sh" -type f -execdir ../utils/test/test_setup.sh  \;

--- a/test-all.sh
+++ b/test-all.sh
@@ -8,13 +8,13 @@ function test-setup (){
   return_code=0
   scripts=$(find . -name "setup.sh" -type f -print | sort)
   for script in ${scripts}; do
-    cd $(dirname ${script})
+    cd "$(dirname "${script}")" || exit 2
     ../utils/test/test_setup.sh setup.sh
     exit_code=$?
     if [ ${exit_code} -ne 0 ]; then
       return_code=${exit_code}
     fi
-    cd $basedir
+    cd "$basedir" || exit 2
   done
   return $return_code
 }

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
-cd basic-commits
-./setup.sh
-cd ..
+#!/usr/bin/env bash
+
+cd basic-commits || exit 1
+../utils/test/test_setup.sh

--- a/utils/make-bare-remote-repo.ps1
+++ b/utils/make-bare-remote-repo.ps1
@@ -4,4 +4,4 @@ if (Test-Path .\remote) {
 }
 
 # Initialize a new remote repository
-git init --bare remote
+git -c init.defaultBranch=master init --bare remote

--- a/utils/make-exercise-repo.ps1
+++ b/utils/make-exercise-repo.ps1
@@ -5,7 +5,7 @@ try {
 	}
 
 	# Initialize a new repository
-	git init exercise
+	git -c init.defaultBranch=master init exercise
 
 	# Go there
 	Set-Location .\exercise\

--- a/utils/make-exercise-repo.sh
+++ b/utils/make-exercise-repo.sh
@@ -5,8 +5,8 @@ make-exercise-repo() {
     rm -rf exercise/
 
     # Initialize a new repository
-    git init exercise
+    git -c init.defaultBranch="$DEFAULT_BRANCH" init exercise
 
     # Go there
-    cd exercise
+    cd exercise || true
 }

--- a/utils/make-fake-remote.sh
+++ b/utils/make-fake-remote.sh
@@ -4,5 +4,5 @@ make-bare-remote-repo() {
     rm -rf remote/
 
     # Initialize a new remote repository
-    git init --bare remote
+    git -c init.defautBranch="$DEFAULT_BRANCH" init --bare remote
 }

--- a/utils/make-setup.sh
+++ b/utils/make-setup.sh
@@ -78,4 +78,4 @@ post-setup () {
     clear-local-gpgsigning
 }
 
-set +e
+[ "$TEST" = true ] || set +e 

--- a/utils/test/test_setup.sh
+++ b/utils/test/test_setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+RC='\033[0m' # Reset Color
+export TEST=true
+
+echo -n "$(basename "$PWD") "
+set +e
+output=$(source setup.sh 2>&1);
+exitcode=$?
+if [ $exitcode = 0 ]; then 
+  echo -e "${GREEN}OK${RC}"
+else
+  echo -e "${RED}FAILED${RC} $(pwd)" 
+  echo "$output"
+fi
+
+unset TEST

--- a/utils/test/test_setup.sh
+++ b/utils/test/test_setup.sh
@@ -15,6 +15,7 @@ if [ $exitcode = 0 ]; then
 else
   echo -e "${RED}FAILED${RC} $(pwd)" 
   echo "$output"
+  exit 2
 fi
 
 unset TEST

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -9,7 +9,7 @@
 #  exit 1
 #fi
 
-
+export DEFAULT_BRANCH=master
 # Using this weird seemingly arbitrary path to avoid path issues. 
 # Please let me know the _right_ way to do this
 source ../utils/make-exercise-repo.sh


### PR DESCRIPTION
This PR includes addition of a test-al.sh script that test-runs the setup.sh of ALL katas, not just the basic-commit one.

To test all katas, run 
```
./test-all.sh
```
from the root folder.

It also includes a `./utils/test/test_setup.sh` can be used to test a single kata (e.g. during development)
Run it from the kata folder as:

```
../utils/test/test_setup.sh
```

While doing this, I noticed that the existing `test.sh` script currently used by the pipeline doesn't actually fail at all if there are problems. So this has now been modified to use the new test_setup.sh script and now fails as it should. (but `test.sh` still only tests the single basic-commits setup).

*NOTE:* The obvious omission in this PR is that the pipeline has not been changed to run the `test-all.sh` script as it obviously should. The reason for this is that I still need to figure out how to get `test-all.sh` to "collect" a summary and exit non-zero if there was one or more tests failing. But I figured the rest was valuable enough to get added now as is. 

Initial work on this PR was done by me, but I want to give a shout-out to @zanderhavgaard for helping me debug and fix the error handling to get it working correctly.