### PR TITLE
Update to use git switch instead of git checkout

### DIFF
--- a/3-way-merge/README.md
+++ b/3-way-merge/README.md
@@ -25,8 +25,8 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 - `git branch`
 - `git branch <branch-name>`
 - `git branch -d <branch-name>`
-- `git checkout <branch-name>`
-- `git checkout -b <branch-name>`
+- `git switch <branch-name>`
+- `git switch -c <branch-name>`
 - `git branch -v`
 - `git add`
 - `git commit`

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ git stash apply <stash>                 # Apply given <stash>, or if none given 
 
 # Working with Branches
 git branch my-branch       # Create a new branch called my-branch
-git checkout my-branch     # Checkout ("Switch" to work on) my-branch
-git checkout -b my-branch  # Create a new branch called my-branch AND switch to it
+git switch my-branch     # Switch to a different branch to work on it
+git switch -c my-branch  # Create a new branch called my-branch AND switch to it
 git branch -d my-branch    # Delete branch my-branch that has been merged with master
 git branch -D my-branch    # Forcefully delete a branch my-branch that hasn't been merged to master
 
@@ -155,10 +155,10 @@ git mv <source/file> <destination/file>   # move/rename file and stage the chang
 # Aliases - it's possible to make aliases of frequently used commands
 #   This is often done to make a command shorter, or to add default flags
 
-# Adding a shorthand "co" for "checkout"
-git config --global alias.co "checkout"
+# Adding a shorthand "sw" for "switch"
+git config --global alias.sw "switch"
 # Usage:
-git co      # Does a "git checkout"
+git sw master     # Does a "git switch master"
 
 ## Logging
 git log --graph --oneline --all # Show a nice graph of the previous commits

--- a/basic-branching/README.md
+++ b/basic-branching/README.md
@@ -7,7 +7,7 @@
 ## The task
 
 You again live in your own branch, this time we will be doing a bit of juggling with branches, to show how lightweight branches are in git.
-Hint: `git switch` and `git checkout` will make you switch from one branch to another.
+Hint: `git switch` will make you switch from one branch to another.
 
 1. Use `git branch` to see the two branches that are relevant for this exercise
 2. What branch are you on?
@@ -31,8 +31,7 @@ Hint: `git switch` and `git checkout` will make you switch from one branch to an
 ## Useful commands
 
 - `git switch`
-- `git checkout`
-- `git checkout -b`
+- `git switch -c`
 - `git log --oneline --graph`
 - `git branch`
 - `git diff`

--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -50,7 +50,6 @@ You live in your own repository. There is a file called `file.txt`.
 - `git commit`
 - `git commit -m "My lazy short commit message"`
 - `git reset`
-- `git checkout`
 - `git log`
 - `git log -n 5`
 - `git log --oneline`

--- a/commit-on-wrong-branch/README.md
+++ b/commit-on-wrong-branch/README.md
@@ -58,7 +58,7 @@ Note: since the `B` in the current and in the target structure don't have the sa
 ## Useful commands
 
 - `git log --oneline --graph --all`
-- `git checkout <branch-name>`
+- `git switch <branch-name>`
 - `git rebase <branch-name>`
 - `git branch <branch-name>`
 - `git reset --soft HEAD~`

--- a/detached-head/README.md
+++ b/detached-head/README.md
@@ -21,5 +21,4 @@ We want to have a branch called `the-beginning` that is made from the first comm
 
 - `git status`
 - `git log --oneline --graph --all`
-- `git checkout <ref>`
-
+- `git checkout <ref>` or `git switch --detach <ref>`

--- a/ff-merge/README.md
+++ b/ff-merge/README.md
@@ -9,7 +9,7 @@
 You again live in your own branch, this time we will be doing a bit of juggling with branches, to show how lightweight branches are in git.
 
 1. Create a (feature)branch called feature/uppercase
-2. Checkout the branch
+2. Switch to this branch
 3. What is the output of `git status`?
 4. Edit the greeting.txt to contain an uppercase greeting
 5. Add greeting.txt files to staging area and commit
@@ -18,7 +18,7 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 
    *Remember: you want to pull in the commit on the feature branch into master. The command 'git merge [branch name]' takes one branch as argument from which it takes commits. The commits are applied to the branch pointed to by HEAD (currently checked out branch).*
 
-8. Checkout `master` branch
+8. Switch to the `master` branch
 9. Use `cat` to see the contents of the greetings
 10. Diff the branches
 11. Merge the branches
@@ -30,7 +30,7 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 - `git branch`
 - `git branch <branch-name>`
 - `git branch -d <branch-name>`
-- `git checkout`
+- `git switch`
 - `git branch -v`
 - `git add`
 - `git commit`

--- a/rebase-branch/README.md
+++ b/rebase-branch/README.md
@@ -14,7 +14,7 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 4. How does the log compare to the log on the master branch?
 5. Rebase your uppercase branch with the master (`git rebase master`)
 6. What did just happen? Draw it!
-7. Now checkout the master branch
+7. Now switch to the master branch
 8. Merge uppercase into master
 9. What does the log look like now?
 

--- a/reverted-merge/README.md
+++ b/reverted-merge/README.md
@@ -49,7 +49,7 @@ features should be included in `mymodule.txt`.
 * `git log --oneline --graph --all`
 * `git add <file-name>`
 * `git revert --continue`
-* `git checkout <branch-name>`
+* `git switch <branch-name>`
 * `git merge <branch-name>`
 * `git reset --hard <sha1>`
 * `git revert <sha1>`


### PR DESCRIPTION
The new commands `git switch`and `git restore` were introduced
in 2.23 back in August 2019, and are much cleaner than the
old `git checkout`, so I believe that we
should be teaching the new way, not the old.

While `git switch` and `git restore` are in principal still marked as
experimental in the documentation, they are here to stay.
Even output from commands like git status,
have gone away from suggesting `git checkout`.

This commit goes through all the README files and makes appropriate
changes to recomend `git switch` instead of `git checkout`
(and `git switch -c` instead of `git checkout -b`)

The actual setup scripts are still left untouched for maximum compatablility.
If you have e.g. participants in a training using very old Git versions,
it is still a lot easier to tell them to use `git checkout`
when `git switch`is mentioned,
than it is to debug scripts that are failing miserably.