### PR TITLE
Use restore for undoing changes

### DIFF
--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -53,7 +53,6 @@ You live in your own repository. There is a file called `file.txt`.
 - `git log -n 5`
 - `git log --oneline`
 - `git log --oneline --graph`
-- `git restore --source`
 - `git restore --staged`
 
 ## Aliases

--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -11,7 +11,7 @@ In git we are working with three different areas:
 A file can have changes both in the working directory and staging area at the same time.
 These changes do not have to be the same.
 
-We will also work with `git reset` to reset the staged changes of a file, and `git checkout` to return a file to a previous state.
+We will also work with `git restore` to restore the staged changes of a file, and `git checkout` to return a file to a previous state.
 
 ## Setup
 
@@ -33,14 +33,14 @@ You live in your own repository. There is a file called `file.txt`.
 10. What does `git diff --staged` tell you?
 11. Explain what is happening
 12. Run `git status` and observe that `file.txt` are present twice in the output.
-13. Run `git reset HEAD file.txt` to unstage the change
+13. Run `git restore --staged file.txt` to unstage the change
 14. What does `git status` tell you now?
 15. Stage the change and make a commit
 16. What does the log look like?
 17. Overwrite the content in `file.txt`: `echo 4 > file.txt` (or `sc file.txt '4'` in PowerShell)
 18. What is the content of `file.txt`?
 19. What does `git status` tell us?
-20. Run `git checkout file.txt`
+20. Run `git restore file.txt`
 21. What is the content of `file.txt`?
 22. What does `git status` tell us?
 
@@ -49,13 +49,12 @@ You live in your own repository. There is a file called `file.txt`.
 - `git add`
 - `git commit`
 - `git commit -m "My lazy short commit message"`
-- `git reset`
 - `git log`
 - `git log -n 5`
 - `git log --oneline`
 - `git log --oneline --graph`
-- `git reset HEAD`
-- `git checkout`
+- `git restore --source`
+- `git restore --staged`
 
 ## Aliases
 


### PR DESCRIPTION
In the training the students learn multiple ways of restoring a file. Both checkout and reset are fine alternatives, but I think restore is the most accurate command for the job. Both checkout and reset also has other purposes where their use makes more sense. For instance reset is used whenever you want to move HEAD.

The training has the approach: "this is what you can do", not "this is what you should do", but I experience that the students got confused with the different ways you could undo changes in a file. However Im open to other viewpoints.