### PR TITLE
Fixed typo in defaultBranch config #319

### DIFF
--- a/utils/make-fake-remote.sh
+++ b/utils/make-fake-remote.sh
@@ -4,5 +4,5 @@ make-bare-remote-repo() {
     rm -rf remote/
 
     # Initialize a new remote repository
-    git -c init.defautBranch="$DEFAULT_BRANCH" init --bare remote
+    git -c init.defaultBranch="$DEFAULT_BRANCH" init --bare remote
 }


### PR DESCRIPTION
When creating new bare repo for fake remote usage, default branch name is
supposed to be set according to variable declared in utils.sh
The git command that creates the repo has the command misspelled and hence
the branch name isn't set correctly. This is only noticeable if the user has
changed their default branch name config to something else than master.

This patch fixes the typo and the config should now work.