### PR TITLE
Fix broken test with git versions >= 2.35.2 #321

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Run setup scripts with Bash
       shell: bash
       run: |
+        git config --global --add safe.directory /__w/git-katas/git-katas
         git --version
         git config --global user.name "GitHub Actions"
         git config --global user.email "nobody@localhost"


### PR DESCRIPTION
As a result of a fix in git for CVE-2022-24765 tests seems to fail on
git versions from 2.35.2

For these to work the working directory has to be added as a git safe
directory.