### PR TITLE
Improve "ignore" kata

### DIFF
--- a/ignore/README.md
+++ b/ignore/README.md
@@ -25,14 +25,14 @@ If you want to signal to Git that a file needs to be removed from git, but still
 8. What does `git status` tell us?
 9. Change `file1.txt`
 10. What does `git status` tell us? Why was the file tracked even though the `txt` extension is in the ignore file?
-11. Make another text file in the repository, what does `git status` look like now? Why is it not tracked?
+11. Make another text file `file2.txt` in the repository, what does `git status` look like now? Why is it not tracked?
 12. Stage the removal of `file1.txt` with the command `git rm --cached`
 13. What does `git status` say?
-14. Create a new file called `file2.txt` and add the line `!file2.txt` to `.gitignore`. (See _note_ below)
+14. Create a new file called `file3.txt` and add the line `!file3.txt` to `.gitignore`. (See _note_ below)
 15. What does `git status` say? Can you think of a use-case for keeping track of a file although the extension is ignored?
 
 ## Note
-If you are using `zsh` instead of `bash`(default on Mac and some Linux') then `echo "!file2.txt" >> .gitignore` will fail because of shell expansion. Either use an editor to modify the file or escape the `!` e.g. `echo "\!file2.txt" >> .gitignore`
+If you are using `zsh` instead of `bash`(default on Mac and some Linux') then `echo "!file3.txt" >> .gitignore` will fail because of shell expansion. Either use an editor to modify the file or escape the `!` e.g. `echo "\!file3.txt" >> .gitignore`
 
 ## Useful commands
 - `git rm`


### PR DESCRIPTION
Added file2.txt in step 11 and changed file2.txt to file3.txt in step 14.

I think it's more intuitive this way as when you go through this kata with file1.txt already present you're tempted to create a file2.txt in step 11. When reaching step 14 you'd be in a correct state when creating file3.txt.