### PR TITLE
Fix typo in rebase explanation in commit-on-wrong-branch kata

### DIFF
--- a/commit-on-wrong-branch/README.md
+++ b/commit-on-wrong-branch/README.md
@@ -48,7 +48,7 @@ Note: since the `B` in the current and in the target structure don't have the sa
 ## The task
 
 1. Use `git log --oneline --graph --all` to view all the branches and their commits.
-2. Copy `C` onto `master` before `B` by rebasing `quickfix` on `master`.
+2. Copy `C` onto `master` before `B` by rebasing `master` on `quickfix`.
 3. Make a new branch (`changes-including-B`) off of our `master` so we can keep working on `B`.
 4. Reset `master` back to `C`.
 5. Delete the `quickfix` branch.


### PR DESCRIPTION
The kata states
> rebase `quickfix` on `master`

When it should state: rebase `master` on `quickfix`.

---

### Example code
```bash
git rebase quickfix master
```

#### When rebasing, you replay the commits of the second argument -master- onto the first argument -quickfix-, therefor, it is only correct to state that master should be rebased on quickfix.

### To go from
```mermaid
%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'mainBranchName': 'remote', 'mainBranchOrder': 2}}}%%
gitGraph
    commit id: "A"
    branch master order: 1
    commit id: "B"
    checkout remote
    branch quickfix order: 3
    commit id: "C"
```

### To
```mermaid
%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'mainBranchName': 'remote', 'mainBranchOrder': 2}}}%%
gitGraph
    commit id: "A"
    branch quickfix order: 3
    commit id: "C"
    branch master order: 1
    commit id: "B"
```
