### PR TITLE
Add note to submodules kata about security workaround

### DIFF
--- a/submodules/README.md
+++ b/submodules/README.md
@@ -5,6 +5,14 @@ This allows you to grab source changes directly, as well as _pushing_ them back.
 
 ## Setup
 
+> NOTE:
+> Unfortunately for us, 2.38.1 introduces a change (due to CVE-2022-39253) that disables git submodule add using the file protocol.
+> as the setup script for this exercise relies on cloning a local repository, it will only work if you specifically allow this before running the script.
+> `git config --global protocol.file.allow always`
+>
+> If you want to remove this "openening" afterwards, you should wait until you are done with the whole exercise, and then run:
+> `git config --global --unset protocol.file.allow`
+
 1. Run `source setup.sh` (or `.\setup.ps1` in PowerShell)
 
 > NOTE: If running setup.sh on windows, you can run into problems by sourcing the setup script. Instead, run `./setup.sh`, and the folders would be created correctly.


### PR DESCRIPTION
As mentioned in #347, there is a new restriction in Git since 2.38.1 which means that we can only run this kata by temporarily loosening the security restrictions.

Until we find a better solution, this at least adds a note with instructions.