### PR TITLE
Fix typo in 3-way-merge README.md

### DIFF
--- a/3-way-merge/README.md
+++ b/3-way-merge/README.md
@@ -31,6 +31,6 @@ You again live in your own branch, this time we will be doing a bit of juggling 
 - `git add`
 - `git commit`
 - `git commit -m`
-- `git merge <branchA> <branchB>`
+- `git merge <branch-name>`
 - `git diff <branchA> <branchB>`
 - `git log --oneline --graph --all`


### PR DESCRIPTION
Corrected the example of the `git merge` command.