### PR TITLE
Fix PowerShell 7 incompatibility with `sc` alias

### DIFF
--- a/basic-commits/README.md
+++ b/basic-commits/README.md
@@ -36,8 +36,8 @@ You can look at the bottom of this file, if you have not yet done basic git conf
 - `git log -n 5`
 - `git log --oneline`
 - `git log --oneline --graph`
-- `touch filename` to create a file (or `sc filename ''` in PowerShell)
-- `echo content > file` to overwrite file with content (or `sc filename 'content'` in PowerShell)
+- `touch filename` to create a file (or `Set-Content filename ''` in PowerShell)
+- `echo content > file` to overwrite file with content (or `Set-Content filename 'content'` in PowerShell)
 - `echo content >> file` to append file with content (or `ac filename 'content'` in PowerShell)
 
 

--- a/basic-staging/README.md
+++ b/basic-staging/README.md
@@ -22,13 +22,13 @@ We will also work with `git restore` to restore the staged changes of a file, an
 You live in your own repository. There is a file called `file.txt`.
 
 1. What's the content of `file.txt`?
-2. Overwrite the content in `file.txt`: `echo 2 > file.txt` to change the state of your file in the working directory (or `sc file.txt '2'` in PowerShell)
+2. Overwrite the content in `file.txt`: `echo 2 > file.txt` to change the state of your file in the working directory (or `Set-Content file.txt '2'` in PowerShell)
 3. What does `git diff` tell you?
 4. What does `git diff --staged` tell you? why is this blank?
 5. Run `git add file.txt` to stage your changes from the working directory.
 6. What does `git diff` tell you?
 7. What does `git diff --staged` tell you?
-8. Overwrite the content in `file.txt`: `echo 3 > file.txt` to change the state of your file in the working directory (or `sc file.txt '3'` in PowerShell).
+8. Overwrite the content in `file.txt`: `echo 3 > file.txt` to change the state of your file in the working directory (or `Set-Content file.txt '3'` in PowerShell).
 9. What does `git diff` tell you?
 10. What does `git diff --staged` tell you?
 11. Explain what is happening
@@ -37,7 +37,7 @@ You live in your own repository. There is a file called `file.txt`.
 14. What does `git status` tell you now?
 15. Stage the change and make a commit
 16. What does the log look like?
-17. Overwrite the content in `file.txt`: `echo 4 > file.txt` (or `sc file.txt '4'` in PowerShell)
+17. Overwrite the content in `file.txt`: `echo 4 > file.txt` (or `Set-Content file.txt '4'` in PowerShell)
 18. What is the content of `file.txt`?
 19. What does `git status` tell us?
 20. Run `git restore file.txt`


### PR DESCRIPTION

The `sc` command, which is aliased to `Set-Content` in older versions of PowerShell, is no longer recognized as an alias in PowerShell 7. This causes issues when running certain katas in the repository.  

Additionally, `sc` is commonly associated with the [Service Control Manager](https://learn.microsoft.com/en-us/windows/win32/services/controlling-a-service-using-sc) in Windows, which can lead to further confusion when executing commands.

To ensure compatibility across different PowerShell versions and avoid ambiguity, this pull request replaces all occurrences of `sc` with `Set-Content`, ensuring the commands work consistently and correctly in both older and newer versions of PowerShell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidance in user-facing instructions for executing file operations by adopting a clearer, more explicit command syntax.
	- Updated steps to ensure consistency across all file creation and modification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->