### PR TITLE
Fix the start version in bad-commit

### DIFF
--- a/Overview.md
+++ b/Overview.md
@@ -36,7 +36,6 @@
 
 ## Katas On Advanced features
 
-1. [git-attributes](git-attributes/README.md) - .gitattributes file allows you to specify how git handles files, such as line endings in text files or how to diff a binary file.
 2. [Bad-commit](bad-commit/README.md) - Using `git bisect` to find a bad commit.
 3. [bisect](bisect/README.md) - Another kata using `git bisect`.
 4. [pre-push](pre-push/README.md) - A quick exercise in using Git hooks.

--- a/Overview.md
+++ b/Overview.md
@@ -30,14 +30,14 @@
 
 1. [commit-on-wrong-branch](commit-on-wrong-branch/README.md) - If we accidentally put unpushed commits on the wrong branch, how do we effectively _move_ them to another branch before our work on that branch.
 1. [commit-on-wrong-branch-2](commit-on-wrong-branch-2/README.md) - Another exercise on what to do if you have accidentally committed on the wrong branch.
-1. [reverted-merge](reverted-merge/README.md) - We revert a merge, but, after fixes are added to the merged branch, we want the changes from merge and the new fixes.
 1. [save-my-commit](save-my-commit/README.md) - Should you accidentally or on purpose delete a commit, go here to try and save it. You will use the reflog.
 1. [detached-head](detached-head/README.md) - git complains that you are in a "You are in 'detached HEAD' state". What do you do?
 1. [change-author](change-author//README.md) - Change the author of commits
 
 ## Katas On Advanced features
 
-1. [Bad-commit](bad-commit/README.md) - Using `git bisect` to find a bad commit.
+1. [reverted-merge](reverted-merge/README.md) - We revert a merge, but, after fixes are added to the merged branch, we want the changes from merge and the new fixes.
+1. [bad-commit](bad-commit/README.md) - Using `git bisect` to find a bad commit.
 1. [bisect](bisect/README.md) - Another kata using `git bisect`.
 1. [pre-push](pre-push/README.md) - A quick exercise in using Git hooks.
 1. [Investigation](investigation/README.md) - Discover what is going on in a Git repo, figure out what it looks like under the hood.

--- a/Overview.md
+++ b/Overview.md
@@ -7,32 +7,33 @@
 ## Basic Git Katas in Suggested Order
 
 1. [basic-commits](basic-commits/README.md) - Very basic creation of commits.
-2. [basic-staging](basic-staging/README.md) - Interacting with the stage (index).
-3. [basic-branching](basic-branching/README.md) - The first stride into branching.
-4. [ff-merge](ff-merge/README.md) - A tour around the most trivial of merges.
-5. [3-way-merge](3-way-merge/README.md) - A basic merge, involving multiple diverged branches.
-6. [merge-conflict](merge-conflict/README.md) - A basic merge between diverging branches with incompatible (but simple) changesets.
-7. [merge-mergesort](merge-mergesort/README.md) - A merge conflict with actual code.
-8. [rebase-branch](rebase-branch/README.md) - Using rebase as an alternative to merging.
-9. [basic-revert](basic-revert/README.md) - Use revert to revert a change
-10. [reset](reset/README.md) - Reset is a powerful and slightly dangerous command if you do not know what you are doing. Go through the three modes of resetting here.
-11. [basic-cleaning](basic-cleaning/README.md) - Cleaning the workspace.
-12. [amend](amend/README.md) - Amending previous commits.
-13. [reorder-the-history](reorder-the-history/README.md) - We might have created our commits in a suboptimal order, practice to fix that scenario here.
-14. [squashing](squashing/README.md) - A lot of small commits is good when you are working locally, but for sharing your code, it might be more beneficial to deliver your code changes in large sets. Go here to experiment with that. Write a good commit
-15. [advanced-rebase-interactive](advanced-rebase-interactive/README.md) - Practice using the interactive rebase commands.
-16. [basic-stashing](basic-stashing/README.md) - The first stride into stashing.
-17. [ignore](ignore/README.md) - The basics of using the `.gitignore` file. And using `git rm`.
-18. [submodules](submodules/README.md) - Submodules are loathed by many. Run through this exercise to see what the ruckus is all about.
-19. [git-tag](git-tag//README.md) - Tags are convenient for keeping track of commits that bump a version number. In this exercise, you will list, add and delete tags.
+1. [basic-staging](basic-staging/README.md) - Interacting with the stage (index).
+1. [basic-branching](basic-branching/README.md) - The first stride into branching.
+1. [ff-merge](ff-merge/README.md) - A tour around the most trivial of merges.
+1. [3-way-merge](3-way-merge/README.md) - A basic merge, involving multiple diverged branches.
+1. [merge-conflict](merge-conflict/README.md) - A basic merge between diverging branches with incompatible (but simple) changesets.
+1. [merge-mergesort](merge-mergesort/README.md) - A merge conflict with actual code.
+1. [rebase-branch](rebase-branch/README.md) - Using rebase as an alternative to merging.
+1. [basic-revert](basic-revert/README.md) - Use revert to revert a change
+1. [reset](reset/README.md) - Reset is a powerful and slightly dangerous command if you do not know what you are doing. Go through the three modes of resetting here.
+1. [basic-cleaning](basic-cleaning/README.md) - Cleaning the workspace.
+1. [amend](amend/README.md) - Amending previous commits.
+1. [reorder-the-history](reorder-the-history/README.md) - We might have created our commits in a suboptimal order, practice to fix that scenario here.
+1. [squashing](squashing/README.md) - A lot of small commits is good when you are working locally, but for sharing your code, it might be more beneficial to deliver your code changes in large sets. Go here to experiment with that. Write a good commit
+1. [advanced-rebase-interactive](advanced-rebase-interactive/README.md) - Practice using the interactive rebase commands.
+1. [basic-stashing](basic-stashing/README.md) - The first stride into stashing.
+1. [ignore](ignore/README.md) - The basics of using the `.gitignore` file. And using `git rm`.
+1. [submodules](submodules/README.md) - Submodules are loathed by many. Run through this exercise to see what the ruckus is all about.
+1. [git-tag](git-tag//README.md) - Tags are convenient for keeping track of commits that bump a version number. In this exercise, you will list, add and delete tags.
 
 ## Katas that solve standard problems
 
 1. [commit-on-wrong-branch](commit-on-wrong-branch/README.md) - If we accidentally put unpushed commits on the wrong branch, how do we effectively _move_ them to another branch before our work on that branch.
-2. [commit-on-wrong-branch-2](commit-on-wrong-branch-2/README.md) - Another exercise on what to do if you have accidentally committed on the wrong branch.
-3. [reverted-merge](reverted-merge/README.md) - We revert a merge, but, after fixes are added to the merged branch, we want the changes from merge and the new fixes.
-4. [save-my-commit](save-my-commit/README.md) - Should you accidentally or on purpose delete a commit, go here to try and save it. You will use the reflog.
-5. [detached-head](detached-head/README.md) - git complains that you are in a "You are in 'detached HEAD' state". What do you do?
+1. [commit-on-wrong-branch-2](commit-on-wrong-branch-2/README.md) - Another exercise on what to do if you have accidentally committed on the wrong branch.
+1. [reverted-merge](reverted-merge/README.md) - We revert a merge, but, after fixes are added to the merged branch, we want the changes from merge and the new fixes.
+1. [save-my-commit](save-my-commit/README.md) - Should you accidentally or on purpose delete a commit, go here to try and save it. You will use the reflog.
+1. [detached-head](detached-head/README.md) - git complains that you are in a "You are in 'detached HEAD' state". What do you do?
+1. [change-author](change-author//README.md) - Change the author of commits
 
 ## Katas On Advanced features
 

--- a/Overview.md
+++ b/Overview.md
@@ -36,10 +36,8 @@
 
 ## Katas On Advanced features
 
-2. [Bad-commit](bad-commit/README.md) - Using `git bisect` to find a bad commit.
-3. [bisect](bisect/README.md) - Another kata using `git bisect`.
-4. [pre-push](pre-push/README.md) - A quick exercise in using Git hooks.
-5. [Investigation](investigation/README.md) - Discover what is going on in a Git repo, figure out what it looks like under the hood.
-6. [Objects](objects/README.md) - A small exercise into Git internals.
-7. [merge-driver](merge-driver/README.md) - Defining a custom merge driver.
-8. [rebase-exec](rebase-exec/README.md) - Run tests on every commit using `git rebase --exec`
+1. [Bad-commit](bad-commit/README.md) - Using `git bisect` to find a bad commit.
+1. [bisect](bisect/README.md) - Another kata using `git bisect`.
+1. [pre-push](pre-push/README.md) - A quick exercise in using Git hooks.
+1. [Investigation](investigation/README.md) - Discover what is going on in a Git repo, figure out what it looks like under the hood.
+1. [rebase-exec](rebase-exec/README.md) - Run tests on every commit using `git rebase --exec`

--- a/bad-commit/README.md
+++ b/bad-commit/README.md
@@ -17,7 +17,7 @@ For this exercise, the version is bad if `badfile` exists.
 
 1. Start `git bisect`.
 2. Usually the HEAD is "bad", as it is in this exercise. Use `git bisect bad` to indicate it.
-3. Usually some old version will be good. In this exercise, the start version is. Use `git bisect good <commit-ish>` to indicate it.
+3. Usually some old version will be good. In this exercise, the start version is `63e1df85cb135e97e562c8f15f883bb4e5137e8c`. Use `git bisect good <commit-ish>` to indicate it.
 4. `git bisect` will then checkout various commits to find the bad commit. Continue indicating the state until it tells you the first bad commit. Keep track of this commit.
 5. Run `git bisect reset` so we can work on the repository.
 6. Use `git diff` to make sure that the bad commit only introduced `badfile`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified bisect instructions by adding a concrete start commit reference and a new step to revert the identified commit.
  * Reorganized kata listings: reordered and renumbered several sections, promoted items (e.g., Bad-commit, bisect, pre-push, Investigation, rebase-exec) and removed/relocated older entries such as git-attributes, Objects, and merge-driver.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->