### PR TITLE
Fixed submodules exercise to work with newer git versions

### DIFF
--- a/submodules/README.md
+++ b/submodules/README.md
@@ -19,7 +19,7 @@ After running the setup script, you'll be left with three repositories inside th
 
 Go to the `product` repository.
 
-1. Add component as a submodule of product by running `git-c protocol.file.allow=always submodule add ../remote include`.
+1. Add component as a submodule of product by running `git -c protocol.file.allow=always submodule add ../remote include`.
 > NOTE: Newer git versions block file protocol by default. 'git -c protocol.file.allow=always' is a temporary one-time override for just this command.
 2. What does your working directory look like?
 3. Does `git status` look like you expect?

--- a/submodules/README.md
+++ b/submodules/README.md
@@ -19,7 +19,8 @@ After running the setup script, you'll be left with three repositories inside th
 
 Go to the `product` repository.
 
-1. Add component as a submodule of product by running `git submodule add ../remote include`.
+1. Add component as a submodule of product by running `git-c protocol.file.allow=always submodule add ../remote include`.
+> NOTE: Newer git versions block file protocol by default. 'git -c protocol.file.allow=always' is a temporary one-time override for just this command.
 2. What does your working directory look like?
 3. Does `git status` look like you expect?
 4. What if you cd to `include`?


### PR DESCRIPTION
# Fix Git submodule lesson

## Summary 
The command `git submodule add ../remote include` fails as newer git versions block file protocol by default
`git -c protocol.file.allow=always` is a temporary one-time override for just this command.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the submodule setup instructions to use a one-time Git command override that allows the file protocol on newer Git versions by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->